### PR TITLE
fix: add judgment about JSXEmptyExpression node;

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,6 @@ export default function({ types: t }) {
     let nextJSXElCondition;
     if (path.isJSXElement()) {
       nextJSXElCondition = getCondition(path.node);
-      console.log(nextJSXElCondition.type);
       if (nextJSXElCondition.type !== directiveIf) {
         return true;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -37,39 +37,30 @@ export default function({ types: t }) {
    */
 
   function isDirectiveIf(condition) {
-    if (
+    return (
       condition !== null &&
       condition.value !== null &&
       condition.type === directiveIf
-    ) {
-      return true;
-    }
-    return false;
+    );
   }
 
   /**
    * Check if the node is an empty text node
    */
 
-  function isEmptyTextNode(path) {
-    if (path.isJSXText() && path.node.value.trim() === "") {
-      return true;
-    }
-    return false;
+  function isEmptyTextNode(node) {
+    return t.isJSXText(node) && node.value.trim() === "";
   }
 
   /**
    * Check if the node is a comment node
    */
 
-  function isCommentNode(path) {
-    if (
-      path.isJSXExpressionContainer() &&
-      path.node.expression.type === "JSXEmptyExpression"
-    ) {
-      return true;
-    }
-    return false;
+  function isCommentExpressionContainer(node) {
+    return (
+      t.isJSXExpressionContainer(node) &&
+      t.isJSXEmptyExpression(node.expression)
+    );
   }
 
   /**
@@ -115,8 +106,8 @@ export default function({ types: t }) {
           do {
             nextJSXElPath = nextJSXElPath.getSibling(nextJSXElPath.key + 1);
             if (
-              isEmptyTextNode(nextJSXElPath) ||
-              isCommentNode(nextJSXElPath)
+              isEmptyTextNode(nextJSXElPath.node) ||
+              isCommentExpressionContainer(nextJSXElPath.node)
             ) {
               // if the nextJSXElPath node is an empty text node or a comment node, keep looping
               continueSearch = true;

--- a/test/fixtures/example/actual.js
+++ b/test/fixtures/example/actual.js
@@ -1,11 +1,36 @@
 import { createElement } from 'react';
 
 function Foo(props) {
+  const renderBlock = function () {
+    return <View>Block</View>;
+  };
   return (
     <View {...props} x-if={true} className="container">
-      <View x-if={condition}>First</View>
-      <View x-if={condition}>First</View><View x-elseif={another}>Second</View><View x-else>Third</View>
+      <View x-if={ifCondition}>First</View>
+      {/* comment1 */}
+      <View x-if={ifCondition}>
+        x-if show
+        {/* comment1-1 */}
+        <View x-if={ifCondition}>x-if x-if show</View>
+        {/* comment1-2 */}
+        <View x-elseif={elseifCondition}>x-if x-elseif show</View>
+        {/* comment1-3 */}
+        <View x-else>x-if x-else show</View>
+      </View>
+      {/* comment2 */}
+      <View x-elseif={elseifCondition}>
+        x-elseif show
+        <View x-if={ifCondition}>x-elseif x-if show</View>
+        {renderBlock()}
+        <View x-elseif={elseifCondition}>x-elseif x-elseif show</View>
+        <View x-else>x-elseif x-else show</View>
+      </View>
+      <View x-else>
+        x-else show
+        <View x-if={ifCondition}>x-else x-if show</View>
+        <View x-else>x-else x-else show</View>
+      </View>
       <View x-else>Third</View>
     </View>
-  )
+  );
 }

--- a/test/fixtures/example/actual.js
+++ b/test/fixtures/example/actual.js
@@ -32,5 +32,5 @@ function Foo(props) {
       </View>
       <View x-else>Third</View>
     </View>
-  );
+  )
 }

--- a/test/fixtures/example/expected.js
+++ b/test/fixtures/example/expected.js
@@ -2,9 +2,45 @@ import { createCondition as __create_condition__ } from "babel-runtime-jsx-plus"
 import { createElement } from 'react';
 
 function Foo(props) {
+  const renderBlock = function () {
+    return <View>Block</View>;
+  };
+
   return __create_condition__([[() => true, () => <View {...props} className="container">
-      {__create_condition__([[() => condition, () => <View>First</View>]])}
-      {__create_condition__([[() => condition, () => <View>First</View>], [() => another, () => <View>Second</View>], [() => true, () => <View>Third</View>]])}
+      {__create_condition__([[() => ifCondition, () => <View>First</View>]])}
+      {
+      /* comment1 */
+    }
+      {__create_condition__([[() => ifCondition, () => <View>
+        x-if show
+        {
+        /* comment1-1 */
+      }
+        {__create_condition__([[() => ifCondition, () => <View>x-if x-if show</View>], [() => elseifCondition, () => <View>x-if x-elseif show</View>], [() => true, () => <View>x-if x-else show</View>]])}
+        {
+        /* comment1-2 */
+      }
+        
+        {
+        /* comment1-3 */
+      }
+        
+      </View>], [() => elseifCondition, () => <View>
+        x-elseif show
+        {__create_condition__([[() => ifCondition, () => <View>x-elseif x-if show</View>]])}
+        {renderBlock()}
+        <View x-elseif={elseifCondition}>x-elseif x-elseif show</View>
+        <View x-else>x-elseif x-else show</View>
+      </View>], [() => true, () => <View>
+        x-else show
+        {__create_condition__([[() => ifCondition, () => <View>x-else x-if show</View>], [() => true, () => <View>x-else x-else show</View>]])}
+        
+      </View>]])}
+      {
+      /* comment2 */
+    }
+      
+      
       <View x-else>Third</View>
     </View>]]);
 }


### PR DESCRIPTION
Error Case: 
`render() {

    const ifCondition = true;
    const elseifCondition = false;
    return (
      <div>
        <div x-if={ifCondition}>x-if show</div>
        {/* comment */}
        <div x-elseif={elseifCondition}>x-elseif show</div>
        <div x-else>x-else show</div>
      </div>
    );
  }`
All these nodes are rendered.

In addition to fixing the bug, it also extracts judgment conditions and adds some comments.
